### PR TITLE
incorrect center of bounding box

### DIFF
--- a/scripts/detect_ros.py
+++ b/scripts/detect_ros.py
@@ -142,8 +142,8 @@ class Detector:
         obj.results.append(obj_hypothesis)
         obj.bbox.size_y = int((dimensions[2]-dimensions[0])*image_height)
         obj.bbox.size_x = int((dimensions[3]-dimensions[1] )*image_width)
-        obj.bbox.center.x = int((dimensions[1] + dimensions [3])*image_height/2)
-        obj.bbox.center.y = int((dimensions[0] + dimensions[2])*image_width/2)
+        obj.bbox.center.x = int((dimensions[1] + dimensions [3])*image_width/2)
+        obj.bbox.center.y = int((dimensions[0] + dimensions[2])*image_height/2)
 
         return obj
 


### PR DESCRIPTION
Hi,

Found this bug while fusing the bounding box's center with RGBD data.
The bug causes the published bounding box's center to have incorrect ranges for both x and y axes.
For instance, the center's x axis (image width) will have a range of 0 - 480, rather than 0 - 640 in a 640 x 480 image.